### PR TITLE
Fix FileNotFoundError in pip install

### DIFF
--- a/mmdetection/setup.py
+++ b/mmdetection/setup.py
@@ -9,51 +9,45 @@ import warnings
 from setuptools import find_packages, setup
 
 import torch
-from torch.utils.cpp_extension import (BuildExtension, CppExtension,
-                                       CUDAExtension)
+from torch.utils.cpp_extension import BuildExtension, CppExtension, CUDAExtension
 
 
-def readme():
-    with open('README.md', encoding='utf-8') as f:
-        content = f.read()
-    return content
-
-
-version_file = 'mmdet/version.py'
+version_file = "mmdet/version.py"
 
 
 def get_version():
-    with open(version_file, 'r') as f:
-        exec(compile(f.read(), version_file, 'exec'))
-    return locals()['__version__']
+    with open(version_file, "r") as f:
+        exec(compile(f.read(), version_file, "exec"))
+    return locals()["__version__"]
 
 
 def make_cuda_ext(name, module, sources, sources_cuda=[]):
 
     define_macros = []
-    extra_compile_args = {'cxx': []}
+    extra_compile_args = {"cxx": []}
 
-    if torch.cuda.is_available() or os.getenv('FORCE_CUDA', '0') == '1':
-        define_macros += [('WITH_CUDA', None)]
+    if torch.cuda.is_available() or os.getenv("FORCE_CUDA", "0") == "1":
+        define_macros += [("WITH_CUDA", None)]
         extension = CUDAExtension
-        extra_compile_args['nvcc'] = [
-            '-D__CUDA_NO_HALF_OPERATORS__',
-            '-D__CUDA_NO_HALF_CONVERSIONS__',
-            '-D__CUDA_NO_HALF2_OPERATORS__',
+        extra_compile_args["nvcc"] = [
+            "-D__CUDA_NO_HALF_OPERATORS__",
+            "-D__CUDA_NO_HALF_CONVERSIONS__",
+            "-D__CUDA_NO_HALF2_OPERATORS__",
         ]
         sources += sources_cuda
     else:
-        print(f'Compiling {name} without CUDA')
+        print(f"Compiling {name} without CUDA")
         extension = CppExtension
 
     return extension(
-        name=f'{module}.{name}',
-        sources=[os.path.join(*module.split('.'), p) for p in sources],
+        name=f"{module}.{name}",
+        sources=[os.path.join(*module.split("."), p) for p in sources],
         define_macros=define_macros,
-        extra_compile_args=extra_compile_args)
+        extra_compile_args=extra_compile_args,
+    )
 
 
-def parse_requirements(fname='requirements.txt', with_version=True):
+def parse_requirements(fname="requirements.txt", with_version=True):
     """Parse the package dependencies listed in a requirements file but strips
     specific versioning information.
 
@@ -70,61 +64,61 @@ def parse_requirements(fname='requirements.txt', with_version=True):
     import re
     import sys
     from os.path import exists
+
     require_fpath = fname
 
     def parse_line(line):
         """Parse information from a line in a requirements text file."""
-        if line.startswith('-r '):
+        if line.startswith("-r "):
             # Allow specifying requirements in other files
-            target = line.split(' ')[1]
+            target = line.split(" ")[1]
             for info in parse_require_file(target):
                 yield info
         else:
-            info = {'line': line}
-            if line.startswith('-e '):
-                info['package'] = line.split('#egg=')[1]
-            elif '@git+' in line:
-                info['package'] = line
+            info = {"line": line}
+            if line.startswith("-e "):
+                info["package"] = line.split("#egg=")[1]
+            elif "@git+" in line:
+                info["package"] = line
             else:
                 # Remove versioning from the package
-                pat = '(' + '|'.join(['>=', '==', '>']) + ')'
+                pat = "(" + "|".join([">=", "==", ">"]) + ")"
                 parts = re.split(pat, line, maxsplit=1)
                 parts = [p.strip() for p in parts]
 
-                info['package'] = parts[0]
+                info["package"] = parts[0]
                 if len(parts) > 1:
                     op, rest = parts[1:]
-                    if ';' in rest:
+                    if ";" in rest:
                         # Handle platform specific dependencies
                         # http://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-platform-specific-dependencies
-                        version, platform_deps = map(str.strip,
-                                                     rest.split(';'))
-                        info['platform_deps'] = platform_deps
+                        version, platform_deps = map(str.strip, rest.split(";"))
+                        info["platform_deps"] = platform_deps
                     else:
                         version = rest  # NOQA
-                    info['version'] = (op, version)
+                    info["version"] = (op, version)
             yield info
 
     def parse_require_file(fpath):
-        with open(fpath, 'r') as f:
+        with open(fpath, "r") as f:
             for line in f.readlines():
                 line = line.strip()
-                if line and not line.startswith('#'):
+                if line and not line.startswith("#"):
                     for info in parse_line(line):
                         yield info
 
     def gen_packages_items():
         if exists(require_fpath):
             for info in parse_require_file(require_fpath):
-                parts = [info['package']]
-                if with_version and 'version' in info:
-                    parts.extend(info['version'])
-                if not sys.version.startswith('3.4'):
+                parts = [info["package"]]
+                if with_version and "version" in info:
+                    parts.extend(info["version"])
+                if not sys.version.startswith("3.4"):
                     # apparently package_deps are broken in 3.4
-                    platform_deps = info.get('platform_deps')
+                    platform_deps = info.get("platform_deps")
                     if platform_deps is not None:
-                        parts.append(';' + platform_deps)
-                item = ''.join(parts)
+                        parts.append(";" + platform_deps)
+                item = "".join(parts)
                 yield item
 
     packages = list(gen_packages_items())
@@ -140,23 +134,23 @@ def add_mim_extension():
     """
 
     # parse installment mode
-    if 'develop' in sys.argv:
+    if "develop" in sys.argv:
         # installed by `pip install -e .`
-        if platform.system() == 'Windows':
+        if platform.system() == "Windows":
             # set `copy` mode here since symlink fails on Windows.
-            mode = 'copy'
+            mode = "copy"
         else:
-            mode = 'symlink'
-    elif 'sdist' in sys.argv or 'bdist_wheel' in sys.argv:
+            mode = "symlink"
+    elif "sdist" in sys.argv or "bdist_wheel" in sys.argv:
         # installed by `pip install .`
         # or create source distribution by `python setup.py sdist`
-        mode = 'copy'
+        mode = "copy"
     else:
         return
 
-    filenames = ['tools', 'configs', 'demo', 'model-index.yml']
+    filenames = ["tools", "configs", "demo", "model-index.yml"]
     repo_path = osp.dirname(__file__)
-    mim_path = osp.join(repo_path, 'mmdet', '.mim')
+    mim_path = osp.join(repo_path, "mmdet", ".mim")
     os.makedirs(mim_path, exist_ok=True)
 
     for filename in filenames:
@@ -169,52 +163,52 @@ def add_mim_extension():
             elif osp.isdir(tar_path):
                 shutil.rmtree(tar_path)
 
-            if mode == 'symlink':
+            if mode == "symlink":
                 src_relpath = osp.relpath(src_path, osp.dirname(tar_path))
                 os.symlink(src_relpath, tar_path)
-            elif mode == 'copy':
+            elif mode == "copy":
                 if osp.isfile(src_path):
                     shutil.copyfile(src_path, tar_path)
                 elif osp.isdir(src_path):
                     shutil.copytree(src_path, tar_path)
                 else:
-                    warnings.warn(f'Cannot copy file {src_path}.')
+                    warnings.warn(f"Cannot copy file {src_path}.")
             else:
-                raise ValueError(f'Invalid mode {mode}')
+                raise ValueError(f"Invalid mode {mode}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     add_mim_extension()
     setup(
-        name='mmdet',
+        name="mmdet",
         version=get_version(),
-        description='OpenMMLab Detection Toolbox and Benchmark',
-        long_description=readme(),
-        long_description_content_type='text/markdown',
-        author='MMDetection Contributors',
-        author_email='openmmlab@gmail.com',
-        keywords='computer vision, object detection',
-        url='https://github.com/open-mmlab/mmdetection',
-        packages=find_packages(exclude=('configs', 'tools', 'demo')),
+        description="OpenMMLab Detection Toolbox and Benchmark",
+        long_description_content_type="text/markdown",
+        author="MMDetection Contributors",
+        author_email="openmmlab@gmail.com",
+        keywords="computer vision, object detection",
+        url="https://github.com/open-mmlab/mmdetection",
+        packages=find_packages(exclude=("configs", "tools", "demo")),
         include_package_data=True,
         classifiers=[
-            'Development Status :: 5 - Production/Stable',
-            'License :: OSI Approved :: Apache Software License',
-            'Operating System :: OS Independent',
-            'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.7',
-            'Programming Language :: Python :: 3.8',
-            'Programming Language :: Python :: 3.9',
+            "Development Status :: 5 - Production/Stable",
+            "License :: OSI Approved :: Apache Software License",
+            "Operating System :: OS Independent",
+            "Programming Language :: Python :: 3",
+            "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
+            "Programming Language :: Python :: 3.9",
         ],
-        license='Apache License 2.0',
-        install_requires=parse_requirements('requirements/runtime.txt'),
+        license="Apache License 2.0",
+        install_requires=parse_requirements("requirements/runtime.txt"),
         extras_require={
-            'all': parse_requirements('requirements.txt'),
-            'tests': parse_requirements('requirements/tests.txt'),
-            'build': parse_requirements('requirements/build.txt'),
-            'optional': parse_requirements('requirements/optional.txt'),
-            'mim': parse_requirements('requirements/mminstall.txt'),
+            "all": parse_requirements("requirements.txt"),
+            "tests": parse_requirements("requirements/tests.txt"),
+            "build": parse_requirements("requirements/build.txt"),
+            "optional": parse_requirements("requirements/optional.txt"),
+            "mim": parse_requirements("requirements/mminstall.txt"),
         },
         ext_modules=[],
-        cmdclass={'build_ext': BuildExtension},
-        zip_safe=False)
+        cmdclass={"build_ext": BuildExtension},
+        zip_safe=False,
+    )


### PR DESCRIPTION
When running `install.sh` it errors in step `pip install -e mmdetection`:

```
Obtaining file:///LineFormer/mmdetection
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [8 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/LineFormer/mmdetection/setup.py", line 192, in <module>
          long_description=readme(),
        File "/LineFormer/mmdetection/setup.py", line 17, in readme
          with open('README.md', encoding='utf-8') as f:
      FileNotFoundError: [Errno 2] No such file or directory: 'README.md'
      [end of output]
```

This PR includes formatting using black and a dirty fix to the described error which simply deletes the relevant line in setup.py (no impact on functionality).